### PR TITLE
Replace Create by OpenFile

### DIFF
--- a/gobdb.go
+++ b/gobdb.go
@@ -108,7 +108,7 @@ func (db Gobdb[T]) List() []T {
 //	during the process, the method returns the error with details about what
 //	went wrong.
 func (db *Gobdb[T]) Add(d ...T) error {
-	file, err := os.Create(db.path)
+	file, err := os.OpenFile(db.path, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
 	if err != nil {
 		return fmt.Errorf("unable to open file: %w", err)
 	}

--- a/gobdb_test.go
+++ b/gobdb_test.go
@@ -30,7 +30,7 @@ func TestAdd(t *testing.T) {
 	want := []string{"barbara", "victor", "walter"}
 	err = db.Add(want...)
 	if err != nil {
-		t.Errorf("unable to add data %v: %s", want, err)
+		t.Fatalf("unable to add data %v: %s", want, err)
 	}
 	got := db.List()
 	if !cmp.Equal(want, got) {


### PR DESCRIPTION
Create truncates the file if it already exists. We should use OpenFile with append mode. Also fixes the test to stop if it cannot write data to the database